### PR TITLE
AGENTS.md/README.mdの整理とセットアップリンク修正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,32 +1,41 @@
-# Repository Guidelines
+# AGENTS Guide
 
-## プロジェクト構成とモジュール整理
-このリポジトリは、個人用の dotfiles とセットアップ用スクリプトを管理します。
-- `fish/` は Fish の設定・補完・関数を配置します。
-- `nvim/` は Neovim 設定を配置します（Lua は `nvim/lua/`）。
-- `git/` は Git 設定と補助スクリプトを配置します（例: `git/scripts/new-branch.sh`）。
-- `bin/` は `~/bin` 向けの小さなユーティリティを配置します。
-- `starship/` と `starship.toml` は Starship の設定です。
-- `mac_install.sh` は macOS の初期セットアップとシンボリックリンク作成を行います。
+このファイルは、Codex などのエージェントがこのリポジトリで作業する際の最小運用ルールです。
 
-## ビルド・テスト・開発コマンド
-- `bash mac_install.sh` は Homebrew パッケージを導入し、設定ファイルをリンクします。
-- `fish -c fisher` は `fisher` 導入後に Fish プラグインを入れます。
-- `nvim` は `~/.config/nvim` にリンク済みの設定で起動します。
+## 利用言語
+- 作業報告・PR 説明・コメントは日本語で簡潔かつ丁寧に記述する。
 
-## コーディングスタイルと命名規則
-- 既存の言語慣習に合わせます。Fish は `set`/`alias` のパターン、Lua は `nvim/lua/` にモジュール分割します。
-- Neovim 設定は `expandtab`、`shiftwidth=2`、`tabstop=4` なので、Lua の編集はこの方針に揃えます。
-- スクリプト名は用途が分かる小文字名を推奨します（例: `git-sweep.fish`）。
+## グローバル設定変更の共有
+- 端末やツールのグローバル設定を変更した場合は、作業報告で必ず明示する。
+- 対象例: `mise use -g`, `git config --global`, `aws configure`, `gh auth login`。
+- 共有の最小セット:
+  - 変更内容（何をどう変更したか）
+  - 反映先ファイル/場所（例: `~/.config/mise/config.toml`）
+  - 必要なら戻し方
 
-## テスト方針
-- 自動テストはありません。
-- スクリプト変更時は簡易確認を行います（例: `fish -n fish/config.fish` で構文チェック、または一度実行）。
+## Git 運用
+- Git 管理下の作業は、原則として開始時に専用 `worktree` を作成する。
+- ブランチは必ず新規作成し、`codex/<task-id>` 形式を使う。
+- `main` / `develop` など共有ブランチへ直接コミットしない。
+- 既存の未コミット変更は勝手に破棄しない。
 
-## コミットとプルリクエスト
-- 既存履歴は日本語の短い説明文が中心です。相似の文体に揃えてください（例: “config.fishでgit pullのエイリアスを追加”）。
-- PR には変更内容の要約と手動確認の結果を記載します。UI 設定が変わる場合のみスクリーンショットを添えます。
+## リポジトリ構成
+- `fish/`: Fish 設定・補完・関数。
+- `nvim/`: Neovim 設定（`nvim/lua/` に Lua モジュール）。
+- `git/`: Git 設定と補助スクリプト。
+- `bin/`: `~/bin` にリンクするユーティリティ。
+- `starship/`: Starship 設定。
+- `mac_install.sh`: macOS 初期セットアップとシンボリックリンク作成。
 
-## セキュリティと設定の注意
-- マシン固有の設定は `~/.config/fish/local.fish` に置きます（`fish/config.fish` から読み込み）。
-- `mac_install.sh` はパッケージ導入とシェル変更を行うため、実行前に内容を確認してください。
+## 変更時の方針
+- 既存スタイルを維持する（Fish は `set`/`alias`、Lua はモジュール分割）。
+- Neovim の Lua 編集は `expandtab` / `shiftwidth=2` / `tabstop=4` に合わせる。
+- マシン固有値は `~/.config/fish/local.fish` へ分離し、リポジトリへ直書きしない。
+
+## 動作確認
+- 自動テストはないため、変更箇所に応じて最小限の検証を行う。
+- 例: `fish -n fish/config.fish`, `bash -n mac_install.sh`。
+
+## コミット/PR
+- コミットメッセージは日本語の短い説明を基本にする。
+- PR には「変更要約」と「手動確認結果」を含める。

--- a/README.md
+++ b/README.md
@@ -2,42 +2,56 @@
 
 macOS 向けの個人用セットアップ。Homebrew でツールを入れ、シンボリックリンクで設定を張ります。
 
-## セットアップ手順
+## セットアップ
 1. Xcode Command Line Tools を入れていない場合は `xcode-select --install` を実行。
-2. リポジトリを取得してスクリプトを実行:
+2. リポジトリを取得して実行:
    ```bash
    git clone https://github.com/yaitaimo/dotfiles.git
    cd dotfiles
    ./mac_install.sh
    ```
-   - Homebrew で CLI/GUI ツールをインストール
-   - fish をログインシェルに設定（sudo で /etc/shells 追記と `chsh`）
-   - dotfiles を `~/.config` などへ symlink
-   - Fisher と fish プラグインを導入
+3. 主な処理内容:
+- Homebrew で CLI/GUI ツールを導入
+- fish をログインシェルに設定（`/etc/shells` 追記と `chsh`）
+- dotfiles を `~/.config` などへ symlink
+- Fisher と fish プラグインを導入
 
-## 含まれる主な設定
-- Shell: `fish/config.fish`, `starship/starship.toml`
-  - alias: `g`=git, `v`=nvim, `lg`=lazygit ほか
-  - fzf デフォルトコマンドに `ag` を使用
-  - Fisher プラグイン: `jethrokuan/z`, `jethrokuan/fzf`, `decors/fish-ghq`, `wfxr/forgit`
-- Neovim: `nvim/`
-  - `lazy.nvim` 管理、リーダーキー `;`
-  - UI: solarized カラースキーム、lualine
-  - LSP: mason + nvim-lspconfig（lua/ts/python/go など）。`gd`, `gr`, `K`, `<leader>rn`, `<leader>f` などを割当
-  - フォーマット: conform.nvim が保存時に prettier/black/goimports 等を実行
-  - 検索: Telescope（`<leader>p` git ルートのファイルブラウザ、`<leader>lg` live grep、`<leader>b` バッファなど）
-  - 構文: Treesitter で主要言語をインストール
-  - Git: diffview.nvim を `<leader>gd` などで起動
-  - ターミナル: toggleterm（フロート端末、`<Leader>g` で lazygit、Codex/Copilot 用トグルあり）
-  - AI: Copilot 本体と CopilotChat を同梱（必要に応じてトークン設定）
-- tmux: `.tmux.conf`
-  - プレフィックス `Ctrl-t`、`Ctrl-S`/`Ctrl-V` で分割、`Ctrl-R` で再読み込み。マウス有効、クリップボード連携
-- WezTerm: `.wezterm.lua`
-  - macOS のライト/ダークに合わせて Solarized 配色を自動切替
-  - フォントは `RobotoMono Nerd Font`（日本語 fallback あり）、リーダー `Ctrl-t`、`Cmd+Ctrl+f` でフルスクリーン
-- Git ヘルパー
-  - `git/scripts/new-branch.sh`: 変更を stash してベースブランチを最新化後、新規ブランチを作成し stash を戻す
+## ディレクトリ構成
+- `fish/`: Fish 設定・補完・関数（`config.fish`, `functions/*.fish`）。
+- `nvim/`: Neovim 設定（`lazy.nvim` + `lua/plugins_specs/*.lua`）。
+- `git/`: Git 設定と補助スクリプト（`git/scripts/new-branch.sh` など）。
+- `bin/`: `~/bin` 向けユーティリティ。
+- `starship/`: Starship 設定。
+- `mac_install.sh`: macOS 初期セットアップスクリプト。
 
-## メモ
-- フォントは Nerd Fonts から `RobotoMono Nerd Font` を別途インストールしてください。
-- `mac_install.sh` の GUI アプリ（1Password, Raycast など）は手動インストールです。
+## 主な設定内容
+- Shell (`fish/config.fish`)
+- エイリアス例: `g`, `gp`, `v`, `lg`, `we`
+- `FZF_DEFAULT_COMMAND` は `ag -g ""`
+- ローカル上書きは `~/.config/fish/local.fish`
+
+- Neovim (`nvim/`)
+- リーダーキーは `;`
+- LSP: mason + nvim-lspconfig（Lua/Python/TS/Go など）
+- フォーマット: conform.nvim（保存時）
+- 検索: Telescope（`<leader>p`, `<leader>lg`, `<leader>b`）
+- Git: diffview.nvim（`<leader>gd` など）
+- AI: Copilot / CopilotChat / codex.nvim
+
+- Terminal / Multiplexer
+- tmux: プレフィックス `Ctrl-t`
+- WezTerm: Solarized 自動切替、`RobotoMono Nerd Font`
+
+## 日常運用コマンド
+- `fish -n fish/config.fish`: Fish 設定の構文チェック
+- `bash -n mac_install.sh`: セットアップスクリプトの構文チェック
+- `nvim`: リンク済み Neovim 設定で起動
+- `~/bin/git-new-branch <branch-name>`: 作業ブランチ作成補助
+
+## 注意事項
+- `mac_install.sh` はシェル変更（`chsh`）と `sudo` を伴うため、実行前に内容を確認してください。
+- フォントは Nerd Fonts の `RobotoMono Nerd Font` を別途インストールしてください。
+- マシン固有設定は `~/.config/fish/local.fish` に置き、リポジトリには含めない運用を推奨します。
+
+## エージェント運用
+エージェント向けルールは `AGENTS.md` を参照してください。`worktree` 運用、`codex/<task-id>` ブランチ方針、グローバル設定変更時の報告要件を定義しています。

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -93,7 +93,7 @@ ensure_symlink "$current_dir/git/.gitconfig" ~/.gitconfig
 ensure_symlink "$current_dir/git/.gitignore_global" ~/.gitignore_global
 ensure_symlink "$current_dir/.globalrc" ~/.globalrc
 ensure_symlink "$current_dir/.wezterm.lua" ~/.wezterm.lua
-ensure_symlink "$current_dir/starship.toml" ~/.config/starship.toml
+ensure_symlink "$current_dir/starship/starship.toml" ~/.config/starship.toml
 ensure_symlink "$current_dir/starship" ~/.config/starship
 ensure_symlink "$current_dir/nvim" ~/.config/nvim
 


### PR DESCRIPTION
## 概要
- AGENTS.md をエージェント向け運用ルールとして再構成
- README.md をセットアップ/構成/運用コマンド中心に整理
- mac_install.sh の Starship symlink 元を実ファイル構成に合わせて修正

## 変更詳細
- AGENTS.md
  - 利用言語、グローバル設定変更共有、Git/worktree 方針を明文化
  - リポジトリ構成・変更時方針・動作確認・コミット/PR 方針を整理
- README.md
  - セットアップ説明を簡潔化
  - ディレクトリ構成と日常運用コマンドを追加
  - AGENTS.md への導線を追加
- mac_install.sh
  - ~/.config/starship.toml のリンク元を starship/starship.toml に修正

## 確認
- fish -n fish/config.fish
- bash -n mac_install.sh