### PR TITLE
Neovimのblame表示とキーマップを調整

### DIFF
--- a/nvim/lua/plugins_specs/git.lua
+++ b/nvim/lua/plugins_specs/git.lua
@@ -1,5 +1,35 @@
 -- Git-related plugins
 return {
+  -- Fugitive: git integration including full-file blame view
+  {
+    "tpope/vim-fugitive",
+    config = function()
+      local function toggle_git_blame()
+        for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+          local buf = vim.api.nvim_win_get_buf(win)
+          if vim.bo[buf].filetype == "fugitiveblame" then
+            vim.api.nvim_win_close(win, true)
+            return
+          end
+        end
+        vim.cmd("Git blame")
+      end
+
+      vim.keymap.set("n", "<leader>b", toggle_git_blame, { desc = "Git blame toggle (full file)" })
+    end,
+    keys = {
+      { "<leader>b", desc = "Git blame toggle (full file)" },
+    },
+  },
+
+  -- Gitsigns: inline blame and hunk actions
+  {
+    "lewis6991/gitsigns.nvim",
+    opts = {
+      current_line_blame = false,
+    },
+  },
+
   -- Diffview: clean UI for reviewing diffs and history
   {
     "sindrets/diffview.nvim",

--- a/nvim/lua/plugins_specs/telescope.lua
+++ b/nvim/lua/plugins_specs/telescope.lua
@@ -14,7 +14,7 @@ return {
     },
     keys = {
       {
-        "<leader>h",
+        "<leader>fh",
         function()
           require("telescope.builtin").help_tags()
         end,
@@ -47,7 +47,14 @@ return {
       },
       -- 📂 最近開いたファイル（oldfiles）
       {
-        "<leader>fh",
+        "<leader>h",
+        function()
+          require("telescope.builtin").oldfiles()
+        end,
+        desc = "Recent files",
+      },
+      {
+        "<leader>H",
         function()
           require("telescope.builtin").oldfiles()
         end,
@@ -55,7 +62,7 @@ return {
       },
       -- 📑 バッファ一覧（開いているファイル）
       {
-        "<leader>b",
+        "<leader>fb",
         function()
           require("telescope.builtin").buffers()
         end,


### PR DESCRIPTION
## 変更内容
- <leader>b で :Git blame の縦一覧をトグル表示
- <leader>h を最近開いたファイル（oldfiles）に変更
- 既存ヘルプを <leader>fh に退避
- バッファ一覧を <leader>fb に変更

## 確認
- lua -e 'assert(loadfile("nvim/lua/plugins_specs/telescope.lua"))'
- lua -e 'assert(loadfile("nvim/lua/plugins_specs/git.lua"))'