### PR TITLE
[codex] git-sweepでworktreeも整理する

### DIFF
--- a/fish/functions/ask-delete.fish
+++ b/fish/functions/ask-delete.fish
@@ -10,6 +10,7 @@ function ask-delete
     end
 
     set -l branches ""
+    set -l current_pwd (pwd)
 
     # 対象ブランチのリスト取得
     if test $target_remote -eq 1
@@ -43,6 +44,21 @@ function ask-delete
                     git push origin --delete $clean_branch
                     echo -e "✅ \033[32mDeleted remote branch:\033[0m origin/$clean_branch"
                 else
+                    set -l worktree_path (git worktree list --porcelain | awk -v target="refs/heads/$clean_branch" '
+                        $1 == "worktree" { path = $2 }
+                        $1 == "branch" && $2 == target { print path }
+                    ')
+
+                    if test -n "$worktree_path"
+                        if test "$worktree_path" = "$current_pwd"
+                            echo -e "⏭️  \033[33mSkipped active worktree:\033[0m $worktree_path"
+                            continue
+                        end
+
+                        git worktree remove "$worktree_path"
+                        echo -e "🧹 \033[32mRemoved worktree:\033[0m $worktree_path"
+                    end
+
                     # ローカルブランチを削除
                     git branch -D $clean_branch
                     echo -e "✅ \033[32mDeleted local branch:\033[0m $clean_branch"

--- a/fish/functions/git-sweep.fish
+++ b/fish/functions/git-sweep.fish
@@ -1,5 +1,106 @@
+function __git_sweep_default_branch
+    set -l extras_default_branch (git config --get git-extras.default-branch 2>/dev/null)
+    if test -n "$extras_default_branch"
+        echo $extras_default_branch
+        return 0
+    end
+
+    set -l init_default_branch (git config --get init.defaultBranch 2>/dev/null)
+    if test -n "$init_default_branch"
+        echo $init_default_branch
+        return 0
+    end
+
+    echo main
+end
+
+function __git_sweep_worktree_path_for_branch --argument-names branch
+    git worktree list --porcelain | awk -v target="refs/heads/$branch" '
+        $1 == "worktree" { path = $2 }
+        $1 == "branch" && $2 == target { print path }
+    '
+end
+
+function __git_sweep_remove_worktrees_for_branches
+    set -l current_pwd (pwd)
+
+    for branch in $argv
+        set -l worktree_path (__git_sweep_worktree_path_for_branch $branch)
+        if test -z "$worktree_path"
+            continue
+        end
+
+        if test "$worktree_path" = "$current_pwd"
+            continue
+        end
+
+        if git worktree remove "$worktree_path"
+            echo "Removed worktree for $branch: $worktree_path"
+        else
+            echo "Skipped worktree for $branch: $worktree_path"
+        end
+    end
+end
+
+function __git_sweep_merged_branches
+    set -l default_branch (__git_sweep_default_branch)
+    set -l current_branch (git rev-parse --abbrev-ref HEAD)
+
+    for branch in (git for-each-ref refs/heads/ --merged HEAD --format='%(refname:short)')
+        if test "$branch" = "$default_branch"
+            continue
+        end
+
+        if test "$branch" = "$current_branch"
+            continue
+        end
+
+        if string match -q 'svn*' -- $branch
+            continue
+        end
+
+        echo $branch
+    end
+end
+
+function __git_sweep_squashed_branches
+    set -l target_branch (git rev-parse --abbrev-ref HEAD)
+
+    for branch in (git for-each-ref refs/heads/ --format='%(refname:short)')
+        if test "$branch" = "$target_branch"
+            continue
+        end
+
+        set -l merge_base (git merge-base $target_branch $branch 2>/dev/null)
+        if test $status -ne 0
+            continue
+        end
+
+        set -l tree (git rev-parse "$branch^{tree}" 2>/dev/null)
+        if test $status -ne 0
+            continue
+        end
+
+        set -l synthetic_commit (git commit-tree $tree -p $merge_base -m _ 2>/dev/null)
+        if test $status -ne 0
+            continue
+        end
+
+        set -l cherry_result (git cherry $target_branch $synthetic_commit 2>/dev/null)
+        if string match -q -- '-*' $cherry_result
+            echo $branch
+        end
+    end
+end
+
 function git-sweep
+    set -l squashed_branches (__git_sweep_squashed_branches)
+    __git_sweep_remove_worktrees_for_branches $squashed_branches
     git delete-squashed-branches
+
+    set -l merged_branches (__git_sweep_merged_branches)
+    __git_sweep_remove_worktrees_for_branches $merged_branches
     git delete-merged-branches
+
     ask-delete
 end


### PR DESCRIPTION
## 変更内容
- `git-sweep` で自動削除対象の branch に対応する worktree も先に掃除するように変更
- `ask-delete` でも対話削除時に対応 worktree を先に外すように変更

## 背景
- merged / squashed 済み branch を消しても worktree が残ると、後で branch 整理が中途半端になっていたため
- `git-extras` は branch cleanup はできるが worktree cleanup までは面倒を見ないため、ラッパー側で補完した

## 影響
- `git-sweep` 実行時に、削除対象 branch に紐づく未使用 worktree も一緒に整理される
- 現在実行中の worktree は削除しない
- worktree に未コミット変更がある場合は `git worktree remove` が失敗し、安全側でスキップされる

## 確認
- `fish -n fish/functions/git-sweep.fish fish/functions/ask-delete.fish`
