### PR TITLE
[codex] git sweepの削除挙動を修正

### DIFF
--- a/fish/functions/ask-delete.fish
+++ b/fish/functions/ask-delete.fish
@@ -1,4 +1,15 @@
 function ask-delete
+    function __ask_delete_worktree_path_for_branch --argument-names branch
+        git worktree list --porcelain | awk -v target="refs/heads/$branch" '
+            $1 == "worktree" { path = $2 }
+            $1 == "branch" && $2 == target { print path }
+        '
+    end
+
+    function __ask_delete_worktree_is_dirty --argument-names worktree_path
+        test -n "(git -C "$worktree_path" status --porcelain --untracked-files=normal 2>/dev/null)"
+    end
+
     # リモートモードフラグの初期化
     set -l target_remote 0
 
@@ -11,14 +22,15 @@ function ask-delete
 
     set -l branches ""
     set -l current_pwd (pwd)
+    set -l current_branch (git rev-parse --abbrev-ref HEAD)
 
     # 対象ブランチのリスト取得
     if test $target_remote -eq 1
         echo -e "🔍 \033[1mTarget: Remote branches\033[0m"
-        set branches (git branch -r | grep -v 'origin/HEAD' | string trim)
+        set branches (git branch -r --format='%(refname:short)' | string match -rv '^origin/HEAD$')
     else
         echo -e "🔍 \033[1mTarget: Local branches\033[0m"
-        set branches (git branch | string trim)
+        set branches (git branch --format='%(refname:short)')
     end
 
     # ブランチの削除確認ループ
@@ -27,7 +39,12 @@ function ask-delete
         set -l clean_branch (echo $branch | sed 's#^origin/##')
 
         # main, master, develop, 現在のブランチをスキップ
-        if string match -q -r 'main|master|develop|^\*' -- $clean_branch
+        if contains -- $clean_branch main master develop
+            echo -e "⏭️  \033[33mSkipped branch:\033[0m $clean_branch"
+            continue
+        end
+
+        if test "$clean_branch" = "$current_branch"
             echo -e "⏭️  \033[33mSkipped branch:\033[0m $clean_branch"
             continue
         end
@@ -44,10 +61,7 @@ function ask-delete
                     git push origin --delete $clean_branch
                     echo -e "✅ \033[32mDeleted remote branch:\033[0m origin/$clean_branch"
                 else
-                    set -l worktree_path (git worktree list --porcelain | awk -v target="refs/heads/$clean_branch" '
-                        $1 == "worktree" { path = $2 }
-                        $1 == "branch" && $2 == target { print path }
-                    ')
+                    set -l worktree_path (__ask_delete_worktree_path_for_branch $clean_branch)
 
                     if test -n "$worktree_path"
                         if test "$worktree_path" = "$current_pwd"
@@ -55,13 +69,25 @@ function ask-delete
                             continue
                         end
 
-                        git worktree remove "$worktree_path"
-                        echo -e "🧹 \033[32mRemoved worktree:\033[0m $worktree_path"
+                        if __ask_delete_worktree_is_dirty "$worktree_path"
+                            echo -e "⏭️  \033[33mSkipped dirty worktree:\033[0m $worktree_path"
+                            continue
+                        end
+
+                        if git worktree remove "$worktree_path"
+                            echo -e "🧹 \033[32mRemoved worktree:\033[0m $worktree_path"
+                        else
+                            echo -e "⚠️  \033[33mFailed to remove worktree:\033[0m $worktree_path"
+                            continue
+                        end
                     end
 
                     # ローカルブランチを削除
-                    git branch -D $clean_branch
-                    echo -e "✅ \033[32mDeleted local branch:\033[0m $clean_branch"
+                    if git branch -D $clean_branch
+                        echo -e "✅ \033[32mDeleted local branch:\033[0m $clean_branch"
+                    else
+                        echo -e "⚠️  \033[33mFailed to delete local branch:\033[0m $clean_branch"
+                    end
                 end
             case '*'
                 echo -e "⏭️  \033[33mSkipped branch:\033[0m $clean_branch"

--- a/fish/functions/git-sweep.fish
+++ b/fish/functions/git-sweep.fish
@@ -21,6 +21,10 @@ function __git_sweep_worktree_path_for_branch --argument-names branch
     '
 end
 
+function __git_sweep_worktree_is_dirty --argument-names worktree_path
+    test -n "(git -C "$worktree_path" status --porcelain --untracked-files=normal 2>/dev/null)"
+end
+
 function __git_sweep_remove_worktrees_for_branches
     set -l current_pwd (pwd)
 
@@ -34,10 +38,15 @@ function __git_sweep_remove_worktrees_for_branches
             continue
         end
 
+        if __git_sweep_worktree_is_dirty "$worktree_path"
+            echo "Skipped dirty worktree for $branch: $worktree_path"
+            continue
+        end
+
         if git worktree remove "$worktree_path"
             echo "Removed worktree for $branch: $worktree_path"
         else
-            echo "Skipped worktree for $branch: $worktree_path"
+            echo "Skipped worktree for $branch after remove failed: $worktree_path"
         end
     end
 end


### PR DESCRIPTION
## 変更要約
`git sweep` / `ask-delete` のブランチ削除まわりを修正しました。

- dirty な worktree を事前検知して `git worktree remove` を実行しないように変更
- `git worktree remove` 失敗時に成功表示を出さず、ブランチ削除に進まないように変更
- `git branch --format='%(refname:short)'` を使って、表示用の `+` をブランチ名として扱わないように変更

## なぜ必要か
既存実装では、変更や未追跡ファイルを含む worktree に対して `git worktree remove` を実行して `fatal` が出ていました。また、`ask-delete` では `git branch` の表示出力をそのまま使っていたため、`+ codex/...` をブランチ名と誤認して削除に失敗していました。

## 影響
`git sweep` 実行時に dirty な worktree は明示的にスキップされ、誤った成功表示や誤ったブランチ削除が起きにくくなります。

## 確認
- `fish -n fish/functions/git-sweep.fish`
- `fish -n fish/functions/ask-delete.fish`
- dirty な既存 worktree を対象に `__git_sweep_remove_worktrees_for_branches` を実行し、`fatal` ではなくスキップ表示になることを確認
