### PR TITLE
[codex] fishリンクをファイル単位にする

### DIFF
--- a/fish/functions/link_fish_settings.fish
+++ b/fish/functions/link_fish_settings.fish
@@ -10,6 +10,12 @@ function link_fish_settings
 
     # 各ディレクトリに対して処理を実行します。
     for dir in completions conf.d functions
+        if test -L $fish_global_config/$dir
+            rm $fish_global_config/$dir
+        else if test -f $fish_global_config/$dir
+            rm $fish_global_config/$dir
+        end
+
         # グローバル設定の対応するディレクトリを確認します。
         if not test -d $fish_global_config/$dir
             # 存在しない場合はディレクトリを作成します。

--- a/mac_install.sh
+++ b/mac_install.sh
@@ -28,6 +28,31 @@ ensure_symlink() {
   ln -s "$src" "$dest"
 }
 
+ensure_real_directory() {
+  local dir="$1"
+
+  if [ -L "$dir" ]; then
+    rm -f "$dir"
+  elif [ -f "$dir" ]; then
+    rm -f "$dir"
+  fi
+
+  mkdir -p "$dir"
+}
+
+link_directory_entries() {
+  local src_dir="$1"
+  local dest_dir="$2"
+  local src
+
+  ensure_real_directory "$dest_dir"
+
+  for src in "$src_dir"/*; do
+    [ -e "$src" ] || continue
+    ensure_symlink "$src" "$dest_dir/$(basename "$src")"
+  done
+}
+
 ensure_line_in_file() {
   local line="$1"
   local file="$2"
@@ -102,9 +127,6 @@ done
 symlink_pairs=(
   "$current_dir/fish/config.fish:$HOME/.config/fish/config.fish"
   "$current_dir/fish/fishfile:$HOME/.config/fish/fishfile"
-  "$current_dir/fish/conf.d:$HOME/.config/fish/conf.d"
-  "$current_dir/fish/functions:$HOME/.config/fish/functions"
-  "$current_dir/fish/completions:$HOME/.config/fish/completions"
   "$current_dir/.vimrc:$HOME/.vimrc"
   "$current_dir/.vim:$HOME/.vim"
   "$current_dir/.tmux.conf:$HOME/.tmux.conf"
@@ -128,6 +150,10 @@ for pair in "${symlink_pairs[@]}"; do
   dest="${pair#*:}"
   ensure_symlink "$src" "$dest"
 done
+
+link_directory_entries "$current_dir/fish/conf.d" "$HOME/.config/fish/conf.d"
+link_directory_entries "$current_dir/fish/functions" "$HOME/.config/fish/functions"
+link_directory_entries "$current_dir/fish/completions" "$HOME/.config/fish/completions"
 
 # fish シェルをデフォルトに設定
 # fish は使いやすさを重視したコマンドラインシェルです。


### PR DESCRIPTION
## 変更内容
- `mac_install.sh` の fish 設定リンクをディレクトリ単位からファイル単位に変更
- `link_fish_settings.fish` で既存のディレクトリ symlink を実ディレクトリへ切り替えられるように変更

## 背景
- `~/.config/fish/functions` / `conf.d` / `completions` をディレクトリごと symlink していると、Fisher や各プラグインの生成物まで dotfiles リポジトリ配下に見えてしまうため
- repo 管理対象の fish ファイルだけを個別にリンクしたい

## 影響
- fish の管理対象ファイルだけが個別 symlink されるようになる
- 生成物は `~/.config/fish` 側の実ファイルとして残る
- 既存の親ディレクトリ symlink は実ディレクトリへ移行される

## 確認
- `bash -n mac_install.sh`
- `fish -n fish/functions/link_fish_settings.fish`
