### PR TITLE
[codex] Starship の時刻を右プロンプトへ移動

### DIFF
--- a/starship/starship.toml
+++ b/starship/starship.toml
@@ -1,7 +1,8 @@
 command_timeout = 2000
+right_format = "$time"
 
 [time]
 disabled = false
-format = "[$time]($style) "
-style = "bold white"
+format = "[$time]($style)"
+style = "bold bright-black"
 time_format = "%H:%M:%S"


### PR DESCRIPTION
## 変更要約
- Starship の時刻表示を `right_format` に移動
- 入力矢印の左寄せ感を維持するため、左プロンプトから time を除外
- Raised Light で背景に溶けにくいよう時刻色を `bold bright-black` に変更

## 手動確認結果
- `starship explain` で time が右プロンプト側として解釈されることを確認
- `TERM=xterm-256color STARSHIP_CONFIG=... starship prompt --status=0 --cmd-duration=0` でプロンプト生成を確認
- サブエージェントレビュー: findings なし