### PR TITLE
NO-TICKET: ECSタスク選択を検索対応

### DIFF
--- a/bin/ecs-fetch-file.py
+++ b/bin/ecs-fetch-file.py
@@ -104,11 +104,11 @@ def choose_task(ecs: Any, cluster: str, task_arg: str | None) -> str:
             }
         )
 
-    return inquirer.select(
+    return inquirer.fuzzy(
         message="ECS task を選択してください:",
         choices=choices,
         mandatory=True,
-        height=min(20, max(5, len(choices))),
+        max_height=min(20, max(5, len(choices))),
     ).execute()
 
 


### PR DESCRIPTION
## 背景
- ECS task の候補が多い場合、選択式だけでは目的の task を探しにくい

## 目的
- ECS task 選択を incremental search で絞り込めるようにする

## 対応内容
- ECS task prompt を select から fuzzy に変更
- 候補表示の最大高さ指定を fuzzy prompt 用の max_height に変更
