### PR TITLE
NO-TICKET: 保存先パス補完を追加

### DIFF
--- a/bin/ecs-fetch-file.py
+++ b/bin/ecs-fetch-file.py
@@ -160,9 +160,11 @@ def resolve_output(args: argparse.Namespace) -> Path | None:
     if args.remote_path:
         default_name = Path(args.remote_path).name or default_name
 
-    output = args.output or inquirer.text(
+    output = args.output or inquirer.filepath(
         message="保存先 local file path:",
-        default=default_name,
+        default=f"~/{default_name}",
+        instruction="Tab で補完",
+        multicolumn_complete=True,
         mandatory=True,
     ).execute()
 


### PR DESCRIPTION
## 背景
- 保存先 local file path の入力を手打ちだけにすると、ディレクトリ移動や候補確認がしづらい

## 目的
- 保存先 path をホームディレクトリ開始の Tab 補完入力にする

## 対応内容
- 保存先 local file path prompt を filepath prompt に変更
- デフォルト値を remote file 名ベースのホームディレクトリ配下に変更
- Tab 補完の案内と複数列候補表示を有効化
